### PR TITLE
유저 동일 특강 중복신청 제어 테스트, 분산서버 동시성 제어 방식 문서 추가

### DIFF
--- a/src/main/java/com/hhplus/hhplus_special_course/domain/course/domain/UserCourseEnrollment.java
+++ b/src/main/java/com/hhplus/hhplus_special_course/domain/course/domain/UserCourseEnrollment.java
@@ -8,7 +8,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "user_course_enrollment")
+@Table(name = "user_course_enrollment",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_student_id_course_id",
+                        columnNames = {"student_id", "course_id"}
+                )
+        })
 public class UserCourseEnrollment {
 
     @Id


### PR DESCRIPTION
### **커밋 링크**
- [test: 유저가 동일한 특강 중복 신청하는 동시성 테스트 추가](https://github.com/nohsion/hhplus-special-course/commit/0876d3c62673abd38a000f55fb23b9bd503336f5)
- [doc: 분산서버 동시성 제어 방식 문서 추가](https://github.com/nohsion/hhplus-special-course/commit/8902f69b2988ba3047ba4f86c6d1909c3b9c4111)
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1: 테스트를 위해 jpa entity 유니크 제약조건(column 길이 등등..)을 모두 걸어두나요? 실제 DB와 싱크를 매번 맞춰줘야 하는 단점도 있을 것 같은데 현업에서는 어떻게 사용하는지 궁금합니다.
- 리뷰 포인트 2: Named Lock으로 동시성 제어를 구현했는데, 대부분 비관적 락으로 해결을 하는 것 같아서 조심스럽습니다.. 혹시 문제는 없을까요?

### 추가 질문사항
1. 반정규화를 하게 되면 매핑테이블의 row수와 컬럼 값이 매번 일치한다고 가정하는건가요? 만약 누군가 실수로 DB를 건드려서 무결성이 깨진 걸 나중에 알아챌 수 있지 않나요? (아니면 주기적으로 체크를 해야 할까요?)
2. 엔티티 != 도메인이라고 생각하는데, 도메인 패키지 내에 엔티티가 여러개 있을 수 있나요?
3. infra 는 외부 (slack, sms, email 등)이라고 생각했는데 청강이나 멘토링을 들어보면 repository impl도 infra 패키지에 많이 넣더라구요.. repository 패키지가 있는데 왜 impl을 repository가 아닌 infra 패키지에 넣나요?

---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->